### PR TITLE
Rev32 patterns

### DIFF
--- a/patterns/ext-hfs-revision-1.txt
+++ b/patterns/ext-hfs-revision-1.txt
@@ -10,16 +10,6 @@ Noise_NXhfs(rs):
    -> e, f
    <- e, f, ee, ff, s, es
 
-Noise_XNhfs(s):
-   -> e, f
-   <- e, f, ee, ff
-   -> s, se
-
-Noise_XXhfs(s, rs):
-   -> e, f
-   <- e, f, ee, ff, s, es
-   -> s, se
-
 Noise_KNhfs(s):
    -> s
    ...
@@ -32,6 +22,16 @@ Noise_KXhfs(s, rs):
    -> e, f
    <- e, f, ee, ff, se, s, es
 
+Noise_XNhfs(s):
+   -> e, f
+   <- e, f, ee, ff
+   -> s, se
+
+Noise_XXhfs(s, rs):
+   -> e, f
+   <- e, f, ee, ff, s, es
+   -> s, se
+
 Noise_INhfs(s):
    -> e, f, s
    <- e, f, ee, ff, se
@@ -40,30 +40,11 @@ Noise_IXhfs(s, rs):
    -> e, f, s
    <- e, f, ee, ff, se, s, es
 
-Noise_XXfallback+hfs(s, rs, re):
-   <- e, f
+Noise_XXfallback+hfs(e, f, s, rs):
+   -> e, f
    ...
-   -> e, f, ee, ff, s, se
-   <- s, es
-
-Noise_NXnoidh+hfs(rs):
-   -> e, f
-   <- e, f, s, ee, ff, es
-
-Noise_XXnoidh+hfs(s, rs):
-   -> e, f
-   <- e, f, s, ee, ff, es
+   <- e, f, ee, ff, s, es
    -> s, se
-
-Noise_KXnoidh+hfs(s, rs):
-   -> s
-   ...
-   -> e, f
-   <- e, f, s, ee, ff, se, es
-
-Noise_IXnoidh+hfs(s, rs):
-   -> e, f, s
-   <- e, f, s, ee, ff, se, es
 
 // Partially hybrid patterns.
 
@@ -73,13 +54,6 @@ Noise_NKhfs(rs):
    -> e, f, es
    <- e, f, ee, ff
 
-Noise_XKhfs(s, rs):
-   <- s
-   ...
-   -> e, f, es
-   <- e, f, ee, ff
-   -> s, se
-
 Noise_KKhfs(s, rs):
    -> s
    <- s
@@ -87,14 +61,15 @@ Noise_KKhfs(s, rs):
    -> e, f, es, ss
    <- e, f, ee, ff, se
 
+Noise_XKhfs(s, rs):
+   <- s
+   ...
+   -> e, f, es
+   <- e, f, ee, ff
+   -> s, se
+
 Noise_IKhfs(s, rs):
    <- s
    ...
    -> e, f, es, s, ss
-   <- e, f, ee, ff, se
-
-Noise_IKnoidh+hfs(s, rs):
-   <- s
-   ...
-   -> e, f, s, es, ss
    <- e, f, ee, ff, se

--- a/patterns/grammar-abnf.txt
+++ b/patterns/grammar-abnf.txt
@@ -7,6 +7,9 @@
 ; The "pattern-single" element is intended for applications that wish to
 ; provide an API to define the specific pattern to use in a handshake.
 ;
+; The "protocol-name" lexical token describes the structure of Noise
+; protocol names in ABNF.
+;
 ; Productions that start with "extension-" apply to extension features like
 ; Hybrid Forward Secrecy and are not part of the core Noise standard.
 
@@ -18,7 +21,7 @@ pattern-single      = wsp pattern wsp
 
 pattern             = header wsp [pre-message wsp "..." wsp] messages
 
-header              = name wsp "(" wsp params wsp ")" wsp ":"
+header              = "Noise_" pattern-name wsp "(" wsp params wsp ")" wsp ":"
 
 params              = param *(wsp "," wsp param)
 
@@ -49,9 +52,22 @@ extension-token     = "f" / "ff"        ; Hybrid Forward Secrecy
 
 ; Lexical tokens
 
-name                = "Noise_" name-component *("+" name-component)
+protocol-name       = "Noise_" pattern-name "_" dh-algorithms
+                      "_" cipher-algorithms "_" hash-algorithms
 
-name-component      = 1*(ALPHA / DIGIT)
+pattern-name        = base-pattern-name [modifier-name *("+" modifier-name)]
+
+base-pattern-name   = 1*(%x41-5A)           ; 1 or more uppercase letters
+
+modifier-name       = 1*(%x61-7A / DIGIT)   ; Lower case and digits
+
+dh-algorithms       = name-component *("+" name-component)
+
+cipher-algorithms   = name-component *("+" name-component)
+
+hash-algorithms     = name-component *("+" name-component)
+
+name-component      = 1*(ALPHA / DIGIT / "/")
 
 wsp                 = *(WSP / eol / comment)
 

--- a/patterns/grammar-abnf.txt
+++ b/patterns/grammar-abnf.txt
@@ -6,6 +6,9 @@
 ;
 ; The "pattern-single" element is intended for applications that wish to
 ; provide an API to define the specific pattern to use in a handshake.
+;
+; Productions that start with "extension-" apply to extension features like
+; Hybrid Forward Secrecy and are not part of the core Noise standard.
 
 ; Syntactic elements
 
@@ -19,11 +22,16 @@ header              = name wsp "(" wsp params wsp ")" wsp ":"
 
 params              = param *(wsp "," wsp param)
 
-param               = "e" / "f" / "s" / "re" / "rf" / "rs"
+param               = standard-param / extension-param
+
+standard-param      = "e" / "s" / "re" / "rs"
+
+extension-param     = "f" / "rf"        ; Hybrid Forward Secrecy
 
 pre-message         = message-init [wsp message-resp] / message-resp
 
-messages            = *(message-pair wsp) message-init / message-pair
+messages            = *(message-pair wsp) message-init [wsp message-resp] /
+                      message-resp *(wsp message-pair) [wsp message-init]
 
 message-pair        = message-init wsp message-resp
 
@@ -33,7 +41,11 @@ message-resp        = "<-" wsp message-tokens
 
 message-tokens      = message-token *(wsp "," wsp message-token)
 
-message-token       = "e" / "f" / "s" / "ee" / "ss" / "se" / "es" / "ff"
+message-token       = standard-token / extension-token
+
+standard-token      = "e" / "s" / "ee" / "ss" / "se" / "es" / "psk"
+
+extension-token     = "f" / "ff"        ; Hybrid Forward Secrecy
 
 ; Lexical tokens
 

--- a/patterns/noise-revision-32.txt
+++ b/patterns/noise-revision-32.txt
@@ -1,0 +1,93 @@
+// Noise Protocol Framework, Revision 32
+
+// Section 7.2. One-way patterns
+
+Noise_N(rs):
+   <- s
+   ...
+   -> e, es
+
+Noise_K(s, rs):
+   -> s
+   <- s
+   ...
+   -> e, es, ss
+
+Noise_X(s, rs):
+   <- s
+   ...
+   -> e, es, s, ss
+
+// Section 7.3. Interactive patterns
+
+Noise_NN():
+   -> e
+   <- e, ee
+
+Noise_NK(rs):
+   <- s
+   ...
+   -> e, es
+   <- e, ee
+
+Noise_NX(rs):
+   -> e
+   <- e, ee, s, es
+
+Noise_KN(s):
+   -> s
+   ...
+   -> e
+   <- e, ee, se
+
+Noise_KK(s, rs):
+   -> s
+   <- s
+   ...
+   -> e, es, ss
+   <- e, ee, se
+
+Noise_KX(s, rs):
+   -> s
+   ...
+   -> e
+   <- e, ee, se, s, es
+
+Noise_XN(s):
+   -> e
+   <- e, ee
+   -> s, se
+
+Noise_XK(s, rs):
+   <- s
+   ...
+   -> e, es
+   <- e, ee
+   -> s, se
+
+Noise_XX(s, rs):
+   -> e
+   <- e, ee, s, es
+   -> s, se
+
+Noise_IN(s):
+   -> e, s
+   <- e, ee, se
+
+Noise_IK(s, rs):
+   <- s
+   ...
+   -> e, es, s, ss
+   <- e, ee, se
+
+Noise_IX(s, rs):
+   -> e, s
+   <- e, ee, se, s, es
+
+// Section 10.3. Noise Pipes
+
+Noise_XXfallback(e, s, rs):
+   -> e
+   ...
+   <- e, ee, s, es
+   -> s, se

--- a/scripts/noise_patterns.py
+++ b/scripts/noise_patterns.py
@@ -64,9 +64,15 @@ class Pattern:
     def isInteractive(self):
         """
         Determine if this is an interactive pattern; that is, there are
-        multiple messages in the body of the pattern.
+        multiple messages in the body of the pattern or the first message
+        is from the responder (implying that there was a previous initiator).
         """
-        return len(self.messages) >= 2
+        if len(self.messages) >= 2:
+            return True
+        if len(self.messages) == 1:
+            direction, message = self.messages[0]
+            return direction == '<-'
+        return False
 
     def baseName(self):
         """

--- a/scripts/noise_patterns.py
+++ b/scripts/noise_patterns.py
@@ -236,6 +236,7 @@ class PatternTokenizer:
             (r"\bre\b",     lambda scanner,token:"re"),
             (r"\brs\b",     lambda scanner,token:"rs"),
             (r"\brf\b",     lambda scanner,token:"rf"),
+            (r"\bpsk\b",    lambda scanner,token:"psk"),
             (r"<-",         lambda scanner,token:"<-"),
             (r"->",         lambda scanner,token:"->"),
             (r"\.\.\.",     lambda scanner,token:"..."),

--- a/scripts/transform_fallback.py
+++ b/scripts/transform_fallback.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+"""
+Applies the 'fallback' transformation to Noise patterns.
+
+Authors:
+    Rhys Weatherley <rhys.weatherley@gmail.com>
+
+This script is placed into the public domain.
+"""
+
+import sys
+from noise_patterns import *
+
+def combine(list1, list2):
+    result = list(list1)
+    for elem in list2:
+        if not elem in list1:
+            result.append(elem)
+    return result
+
+def make_fallback(orig):
+    pattern = Pattern()
+    pattern.name = orig.name
+    pattern.addTransformation('fallback')
+    direction, first_message = orig.messages[0]
+    pattern.parameters = combine(first_message, orig.parameters)
+    pattern.initiator_premessage = first_message + orig.initiator_premessage
+    pattern.responder_premessage = list(orig.responder_premessage)
+    pattern.messages = []
+    for direction, message in orig.messages[1:]:
+        pattern.messages.append((direction, list(message)))
+    return pattern
+
+def fallback_compatible(pattern):
+    direction, messages = pattern.messages[0];
+    if direction != '->':
+        return False
+    if messages == ['e'] or messages == ['e', 's']:
+        return True
+    return False
+
+if len(sys.argv) <= 1:
+    print "Usage: " + sys.argv[0] + " file ..."
+    sys.exit(1)
+
+for file in sys.argv[1:]:
+    patterns = loadPatterns(file)
+    for pattern in patterns:
+        if not pattern.isInteractive():
+            # Only interactive patterns can be fallback.
+            continue
+        if 'fallback' in pattern.transformations():
+            # The pattern is already fallback.
+            continue
+        if not fallback_compatible(pattern):
+            # The first message is not fallback-compatible.
+            continue
+        fallback = make_fallback(pattern)
+        print fallback
+
+sys.exit(0)

--- a/scripts/transform_psk.py
+++ b/scripts/transform_psk.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+"""
+Applies the 'pskN' transformations to Noise patterns.
+
+Authors:
+    Rhys Weatherley <rhys.weatherley@gmail.com>
+
+This script is placed into the public domain.
+"""
+
+import sys
+from noise_patterns import *
+
+def make_psk(orig, modifier, psk_num):
+    pattern = Pattern()
+    pattern.name = orig.name
+    pattern.addTransformation(modifier)
+    pattern.parameters = list(orig.parameters)
+    pattern.initiator_premessage = list(orig.initiator_premessage)
+    pattern.responder_premessage = list(orig.responder_premessage)
+    pattern.messages = []
+    if psk_num == 0:
+        direction, message = orig.messages[0]
+        pattern.messages.append((direction, ['psk'] + message))
+        for direction, message in orig.messages[1:]:
+            pattern.messages.append((direction, list(message)))
+    else:
+        posn = 1
+        for direction, message in orig.messages:
+            if psk_num == posn:
+                pattern.messages.append((direction, message + ['psk']))
+            else:
+                pattern.messages.append((direction, list(message)))
+            posn += 1
+    return pattern
+
+if len(sys.argv) <= 2:
+    print "Usage: " + sys.argv[0] + " N file ..."
+    sys.exit(1)
+
+psk_num = int(sys.argv[1])
+modifier = "psk" + sys.argv[1]
+
+for file in sys.argv[2:]:
+    patterns = loadPatterns(file)
+    for pattern in patterns:
+        if modifier in pattern.transformations():
+            # The modifier was already applied to this pattern.
+            continue
+        if psk_num > len(pattern.messages):
+            # Cannot apply the modifier to this pattern because
+            # there aren't enough messages in it.
+            continue
+        psk = make_psk(pattern, modifier, psk_num)
+        print psk
+
+sys.exit(0)


### PR DESCRIPTION
* Modify the ABNF pattern grammar for rev32.
* Add ABNF grammar rules for protocol names.
* New pattern dictionary for rev32.
* Python scripts for rev32 syntax and application of 'fallback' and 'pskN' modifiers.
* Update the Hybrid Forward Secrecy draft to use rev32 terminology.